### PR TITLE
Dev refactor requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Work in progress, subject to change. Not ready for production use.
 - [x] Create a macro for `hdr!`(r#"Content-type: application/json#Accept: application/json") to make it easier to create
   headers
 - [ ] Create a macro for `body!`(r#"{"key": "value"}"#) to make it easier to create bodies
-- [ ] Setup a `Request` builder pattern to make it less verbose to create requests
+- [x] Setup a `Request` builder pattern to make it less verbose to create requests
 - [ ] Create a more robust `example using an api` that requires authentication, session management, etc.
 - [ ] Allow for `shared state` such as databases or other resources
 - [ ] More robust custom response and requests in the `context`
@@ -135,14 +135,12 @@ impl Stepable for Facebook {
     }
 
     fn on_request(&mut self) -> Request {
-        Request {
-            method: Method::GET,
-            url: "https://facebook.com".to_string(),
-            headers: None,
-            timeout: Some(Duration::new(30, 0)),
-            body: None,
-            status_codes: Some(vec![200]),
-        }
+        // use the request builder pattern
+        Request::new(Method::GET, "https://facebook.com".to_string())
+            .with_headers(hdr!("Accept-Encoding: gzip, deflate, br"))
+            .with_timeout(Duration::new(60, 0))
+            .with_status_codes(vec![200])
+            .build();
     }
 
     fn on_success(&self, ctx: &mut Context) {

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -36,12 +36,19 @@ impl Bot {
         let res = match req_builder.send().await {
             Ok(res) => res,
             Err(err) => {
-                step.on_error(StepError::ReqwestError(err.to_string()));
+                ctx.set_time_elapsed(stop_watch.elapsed().as_millis() as u64);
+
+                if err.is_timeout() {
+                    step.on_timeout(&mut ctx);
+                    return Err(StepError::ReqwestError(err.to_string()));
+                }
+
+                step.on_error(&mut ctx, StepError::ReqwestError(err.to_string()));
                 return Err(StepError::ReqwestError(err.to_string()));
             }
         };
 
-        ctx.time_elapsed = stop_watch.elapsed().as_millis() as u64;
+        ctx.set_time_elapsed(stop_watch.elapsed().as_millis() as u64);
 
         // Check if the status code is in the list of expected status codes.
         let status_code = res.status().as_u16();
@@ -59,7 +66,7 @@ impl Bot {
                 expected_codes.cloned().unwrap_or_else(Vec::new),
             );
 
-            step.on_error(error.clone());
+            step.on_error(&mut ctx, error.clone());
             return Err(error);
         }
 
@@ -79,9 +86,10 @@ impl Bot {
         http_req.settings.set_user_agent(req.user_agent());
         http_req.settings.set_compression(req.is_compressed());
 
-        let req_builder = http_req.build_reqwest(req).unwrap();
+        let req_builder = http_req.build_reqwest(req.clone()).unwrap();
 
         Context {
+            request: req,
             current_step: None,
             http_requester: http_req,
             request_builder: Some(req_builder),
@@ -96,6 +104,8 @@ impl Bot {
 /// The context for the bots current step's execution.
 /// This is passed to the step's `on_success` and `on_error` methods.
 pub struct Context {
+    /// The original request struct.
+    pub request: Request,
     /// The next step to be executed.
     pub current_step: Option<String>,
     /// The HTTP requester which manages cookie store and client settings.
@@ -139,8 +149,8 @@ pub trait Stepable {
     fn name(&self) -> String;
     fn on_request(&mut self) -> Request;
     fn on_success(&self, ctx: &mut Context);
-    fn on_error(&self, err: StepError);
-    fn on_timeout(&self);
+    fn on_error(&self, ctx: &mut Context, err: StepError);
+    fn on_timeout(&self, ctx: &mut Context);
     // async fn execute(&self, res: StepperResponse) -> Result<StepperResponse, Error>;
 }
 
@@ -226,11 +236,11 @@ mod tests {
             ctx.set_next_step("RobotsTxt".to_string());
         }
 
-        fn on_error(&self, _err: StepError) {
+        fn on_error(&self, ctx: &mut Context, _err: StepError) {
             todo!()
         }
 
-        fn on_timeout(&self) {
+        fn on_timeout(&self, ctx: &mut Context) {
             todo!()
         }
     }
@@ -254,6 +264,7 @@ mod tests {
     async fn bot_should_have_next_step_in_store_as_expected() {
         let step = RobotsTxt {};
         let store = &mut Context {
+            request: Request::default(),
             current_step: None,
             http_requester: HttpRequester::new(),
             request_builder: None,

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -207,14 +207,11 @@ mod tests {
                 Accept: */*"
             );
 
-            Request {
-                method: Method::GET,
-                url: "https://test.com".to_string(),
-                headers: Some(headers),
-                timeout: Some(Duration::new(30, 0)),
-                body: None,
-                status_codes: Some(vec![200]),
-            }
+            Request::new(Method::GET, "https://test.com".to_string())
+                .with_headers(headers)
+                .with_timeout(Duration::new(30, 0))
+                .with_status_codes(vec![200])
+                .build()
         }
 
         fn on_success(&self, ctx: &mut Context) {

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -71,8 +71,14 @@ impl Bot {
     }
 
     fn new_context(req: Request) -> Context {
-        let http_req: HttpRequester = HttpRequester::new();
+        let mut http_req: HttpRequester = HttpRequester::new();
+
+        // set the proxy, user agent, and compression settings before we give up ownership of the request.
         let status_codes = req.status_codes().clone();
+        http_req.settings.set_proxy(req.proxy());
+        http_req.settings.set_user_agent(req.user_agent());
+        http_req.settings.set_compression(req.is_compressed());
+
         let req_builder = http_req.build_reqwest(req).unwrap();
 
         Context {

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -72,7 +72,7 @@ impl Bot {
 
     fn new_context(req: Request) -> Context {
         let http_req: HttpRequester = HttpRequester::new();
-        let status_codes = req.status_codes.clone();
+        let status_codes = req.status_codes().clone();
         let req_builder = http_req.build_reqwest(req).unwrap();
 
         Context {
@@ -266,7 +266,7 @@ mod tests {
         let mut step = RobotsTxt {};
         let req = step.on_request();
 
-        assert_eq!(req.method, Method::GET);
-        assert_eq!(req.status_codes, Some(vec![200]));
+        assert_eq!(req.method(), Method::GET);
+        assert_eq!(req.status_codes(), Some(vec![200]));
     }
 }

--- a/src/client_settings.rs
+++ b/src/client_settings.rs
@@ -34,6 +34,11 @@ impl ClientSettings {
         self.user_agent.as_ref()
     }
 
+    pub fn set_compression(&mut self, gzip: bool) -> &mut Self {
+        self.gzip = gzip;
+        self
+    }
+
     pub fn enable_compression(&mut self) -> &mut Self {
         self.gzip = true;
         self

--- a/src/http_requester.rs
+++ b/src/http_requester.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use reqwest::{Body, Client, IntoUrl, Method, RequestBuilder, Response};
 use reqwest::header::HeaderMap;
+use reqwest::{Body, Client, IntoUrl, Method, RequestBuilder, Response};
 use reqwest_cookie_store::{CookieStore, CookieStoreMutex};
 
 // http_requester.rs
@@ -45,16 +45,21 @@ impl HttpRequester {
     }
 
     /// Sends a request with all of the internal client settings.
-    pub async fn req<U, B, H>(&self, method: Method, url: U, body: B, headers: H) -> Result<Response, reqwest::Error>
-        where U: IntoUrl,
-              B: Into<Option<Body>>,
-              H: Into<Option<HeaderMap>>,
+    pub async fn req<U, B, H>(
+        &self,
+        method: Method,
+        url: U,
+        body: B,
+        headers: H,
+    ) -> Result<Response, reqwest::Error>
+    where
+        U: IntoUrl,
+        B: Into<Option<Body>>,
+        H: Into<Option<HeaderMap>>,
     {
         let client = &self.build_client()?;
 
-        let mut client = client
-            .request(method, url)
-            .timeout(Duration::new(30, 0));
+        let mut client = client.request(method, url).timeout(Duration::new(30, 0));
 
         if let Some(h) = headers.into() {
             client = client.headers(h);
@@ -69,8 +74,7 @@ impl HttpRequester {
     }
 
     /// Sends a request with all of the internal client settings.
-    pub fn build_reqwest(&self, req: Request) -> Result<RequestBuilder, reqwest::Error>
-    {
+    pub fn build_reqwest(&self, req: Request) -> Result<RequestBuilder, reqwest::Error> {
         let client = &self.build_client()?;
 
         let mut client = client
@@ -106,7 +110,6 @@ fn new_cookie_store() -> Arc<CookieStoreMutex> {
     let cookie_store = Arc::new(cookie_store);
     cookie_store
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -150,10 +153,7 @@ mod tests {
         let mut req = HttpRequester::new();
         req.settings.set_user_agent(Some(expected.clone()));
 
-        assert_eq!(
-            req.settings.user_agent().unwrap(),
-            &expected
-        )
+        assert_eq!(req.settings.user_agent().unwrap(), &expected)
     }
 
     #[test]
@@ -190,7 +190,7 @@ mod tests {
                 assert!(format!("{:?}", client).contains("Http(https://secure.example)"));
                 assert!(format!("{:?}", client).contains("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36"));
             }
-            Err(_) => panic!("invalid")
+            Err(_) => panic!("invalid"),
         }
     }
 
@@ -207,6 +207,9 @@ mod tests {
             timeout: Some(Duration::new(35, 0)),
             body: Some(Body::from("fuck yea".to_string())),
             status_codes: Some(vec![200]),
+            proxy: None,
+            user_agent: None,
+            gzip: true,
         };
 
         match http.build_reqwest(req) {
@@ -215,7 +218,7 @@ mod tests {
                 assert!(format!("{:?}", b).contains("google.com"));
                 assert!(format!("{:?}", b).contains("x-api-key"));
             }
-            Err(_) => panic!("invalid")
+            Err(_) => panic!("invalid"),
         }
     }
 
@@ -234,7 +237,7 @@ mod tests {
                 assert!(format!("{:?}", b).contains("method: POST"));
                 assert!(format!("{:?}", b).contains("test.com"));
             }
-            Err(_) => panic!("invalid")
+            Err(_) => panic!("invalid"),
         }
     }
 
@@ -248,7 +251,7 @@ mod tests {
                 assert!(format!("{:?}", b).contains("method: PATCH"));
                 assert!(format!("{:?}", b).contains("aol.com"));
             }
-            Err(_) => panic!("invalid")
+            Err(_) => panic!("invalid"),
         }
     }
 }

--- a/src/http_requester.rs
+++ b/src/http_requester.rs
@@ -113,7 +113,7 @@ fn new_cookie_store() -> Arc<CookieStoreMutex> {
 
 #[cfg(test)]
 mod tests {
-    use crate::request::CloneableBody;
+    use crate::request::MimicBody;
     use reqwest::header::HeaderValue;
     use reqwest::Proxy;
 
@@ -203,7 +203,7 @@ mod tests {
 
         let req = Request::new(Method::POST, "https://google.com".to_string())
             .with_headers(headers)
-            .with_body(CloneableBody::new(vec![2, 3, 4]))
+            .with_body(MimicBody::from_bytes(vec![2, 3, 4]))
             .with_status_codes(vec![200])
             .build();
 

--- a/src/http_requester.rs
+++ b/src/http_requester.rs
@@ -113,6 +113,7 @@ fn new_cookie_store() -> Arc<CookieStoreMutex> {
 
 #[cfg(test)]
 mod tests {
+    use crate::request::CloneableBody;
     use reqwest::header::HeaderValue;
     use reqwest::Proxy;
 
@@ -202,7 +203,7 @@ mod tests {
 
         let req = Request::new(Method::POST, "https://google.com".to_string())
             .with_headers(headers)
-            .with_body(Body::from("fuck yea".to_string()))
+            .with_body(CloneableBody::new(vec![2, 3, 4]))
             .with_status_codes(vec![200])
             .build();
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -5,15 +5,15 @@ use reqwest::{Body, Method};
 
 #[derive(Debug)]
 pub struct Request {
-    pub method: Method,
-    pub url: String,
-    pub headers: Option<HeaderMap>,
-    pub timeout: Option<Duration>,
-    pub body: Option<Body>,
-    pub status_codes: Option<Vec<u16>>,
-    pub proxy: Option<String>,
-    pub user_agent: Option<String>,
-    pub gzip: bool,
+    method: Method,
+    url: String,
+    headers: Option<HeaderMap>,
+    timeout: Option<Duration>,
+    body: Option<Body>,
+    status_codes: Option<Vec<u16>>,
+    proxy: Option<String>,
+    user_agent: Option<String>,
+    gzip: bool,
 }
 
 impl Request {
@@ -31,9 +31,21 @@ impl Request {
         }
     }
 
+    pub fn method(&self) -> Method {
+        self.method.clone()
+    }
+
+    pub fn url(&self) -> &String {
+        &self.url
+    }
+
     pub fn with_headers(mut self, headers: HeaderMap) -> Self {
         self.headers = Some(headers);
         self
+    }
+
+    pub fn headers(&self) -> Option<HeaderMap> {
+        self.headers.clone()
     }
 
     pub fn with_timeout(mut self, timeout: Duration) -> Self {
@@ -41,9 +53,17 @@ impl Request {
         self
     }
 
+    pub fn timeout(&self) -> Option<Duration> {
+        self.timeout.clone()
+    }
+
     pub fn with_body(mut self, body: Body) -> Self {
         self.body = Some(body);
         self
+    }
+
+    pub fn body(self) -> Option<Body> {
+        self.body
     }
 
     pub fn with_status_codes(mut self, status_codes: Vec<u16>) -> Self {
@@ -51,9 +71,17 @@ impl Request {
         self
     }
 
+    pub fn status_codes(&self) -> Option<Vec<u16>> {
+        self.status_codes.clone()
+    }
+
     pub fn with_proxy(mut self, proxy: String) -> Self {
         self.proxy = Some(proxy);
         self
+    }
+
+    pub fn proxy(&self) -> Option<&String> {
+        self.proxy.as_ref()
     }
 
     pub fn with_user_agent(mut self, user_agent: String) -> Self {
@@ -61,9 +89,17 @@ impl Request {
         self
     }
 
+    pub fn user_agent(&self) -> Option<&String> {
+        self.user_agent.as_ref()
+    }
+
     pub fn compressed(mut self) -> Self {
         self.gzip = true;
         self
+    }
+
+    pub fn is_compressed(&self) -> bool {
+        self.gzip
     }
 
     pub fn no_compression(mut self) -> Self {
@@ -170,11 +206,11 @@ mod tests {
             .build();
         assert_eq!(req.method, Method::GET);
         assert_eq!(req.url, "https://google.com");
-        assert_eq!(req.headers.unwrap().len(), 1);
-        assert_eq!(req.timeout.unwrap().as_secs(), 710);
-        assert_eq!(req.status_codes.unwrap().len(), 3);
-        assert_eq!(req.proxy.unwrap(), "https://secure.example");
-        assert_eq!(req.user_agent.unwrap(), "reqwest");
-        assert_eq!(req.gzip, false);
+        assert_eq!(req.headers().unwrap().len(), 1);
+        assert_eq!(req.timeout().unwrap().as_secs(), 710);
+        assert_eq!(req.status_codes().unwrap().len(), 3);
+        assert_eq!(req.proxy().unwrap(), "https://secure.example");
+        assert_eq!(req.user_agent().unwrap(), "reqwest");
+        assert_eq!(req.is_compressed(), false);
     }
 }


### PR DESCRIPTION
[x] Setup a `Request` builder pattern to make it less verbose to create requests

- Introduce `MimicBody` to overcome `reqwest::Body` #[derive(Clone)] limitation: This change allows the `Request` struct to be cloneable, facilitating the passing of the original request object through the `Context`. As a result, event functions in steps can now access additional request data such as method and URL.

- Refactor `Request` Struct for Encapsulation: Replaced public struct variables with a getter/setter approach to improve data encapsulation. Integrated these changes into a builder pattern, streamlining the creation of new `Request` instances via `Request::new()`.