### PR TITLE
Dev add skipping to on request

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Work in progress, subject to change. Not ready for production use.
 - [x] Set up a `Request` builder pattern to make it less verbose to create requests
 - [X] Move `Context` to its own module and remove `pub` from `Context` struct
 - [ ] Allow for `shared state` such as databases or other resources
-- [ ] Allow for skipping steps during `on_request()`
+- [X] Allow for skipping steps during `on_request()`
 - [ ] Create a more robust `example using an api` that requires authentication, session management, etc.
 - [ ] More robust timeout and pause functionality [Timeout, AfterSuccess, AfterError, etc]
 - [ ] Move `Context` to a `ContextBuilder` pattern to make it less verbose to create contexts?

--- a/README.md
+++ b/README.md
@@ -20,15 +20,13 @@ Work in progress, subject to change. Not ready for production use.
 - [x] Basic functionality for a simple recursive bot with multiple steps
 - [x] Create a macro for `hdr!`(r#"Content-type: application/json#Accept: application/json") to make it easier to create
   headers
-- [x] Setup a `Request` builder pattern to make it less verbose to create requests
-- [ ] Move `Context` to a `ContextBuilder` pattern to make it less verbose to create contexts?
-- [ ] Move `Context` to its own module and remove `pub` from `Context` struct
-- [ ] Create a more robust `example using an api` that requires authentication, session management, etc.
+- [x] Set up a `Request` builder pattern to make it less verbose to create requests
+- [X] Move `Context` to its own module and remove `pub` from `Context` struct
 - [ ] Allow for `shared state` such as databases or other resources
-- [ ] Allow for file uploads
-- [ ] More robust custom response and requests in the `context`
 - [ ] Allow for skipping steps during `on_request()`
+- [ ] Create a more robust `example using an api` that requires authentication, session management, etc.
 - [ ] More robust timeout and pause functionality [Timeout, AfterSuccess, AfterError, etc]
+- [ ] Move `Context` to a `ContextBuilder` pattern to make it less verbose to create contexts?
 - [ ] Create a `curl command parser` to transform curl commands to mimicr steps
 
 ## Usage for a 2 step bot

--- a/src/request.rs
+++ b/src/request.rs
@@ -16,6 +16,7 @@ pub struct Request {
     proxy: Option<Proxy>,
     user_agent: Option<String>,
     gzip: bool,
+    skip: bool,
 }
 
 impl Request {
@@ -31,6 +32,7 @@ impl Request {
             proxy: None,
             user_agent: None,
             gzip: true,
+            skip: false,
         }
     }
 
@@ -127,6 +129,15 @@ impl Request {
         self
     }
 
+    pub fn skip(mut self) -> Self {
+        self.skip = true;
+        self
+    }
+
+    pub fn is_skipped(&self) -> bool {
+        self.skip
+    }
+
     pub fn build(self) -> Self {
         self
     }
@@ -145,6 +156,7 @@ impl Default for Request {
             proxy: None,
             user_agent: None,
             gzip: true,
+            skip: false,
         }
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -16,9 +16,12 @@ pub struct Request {
     proxy: Option<Proxy>,
     user_agent: Option<String>,
     gzip: bool,
-    skip: bool,
+    skip_to: Option<String>,
 }
 
+/// A builder for a request.
+/// Note: This needs a skip() method to skip a request.
+/// Also it needs a skip_to() method to skip to a specific step.
 impl Request {
     pub fn new(method: Method, url: String) -> Self {
         Self {
@@ -32,7 +35,7 @@ impl Request {
             proxy: None,
             user_agent: None,
             gzip: true,
-            skip: false,
+            skip_to: None,
         }
     }
 
@@ -129,13 +132,17 @@ impl Request {
         self
     }
 
-    pub fn skip(mut self) -> Self {
-        self.skip = true;
+    pub fn skip_to(mut self, step: Option<String>) -> Self {
+        self.skip_to = step;
         self
     }
 
     pub fn is_skipped(&self) -> bool {
-        self.skip
+        self.skip_to.is_some()
+    }
+
+    pub fn get_skip_to_step(&self) -> Option<String> {
+        self.skip_to.clone()
     }
 
     pub fn build(self) -> Self {
@@ -156,7 +163,7 @@ impl Default for Request {
             proxy: None,
             user_agent: None,
             gzip: true,
-            skip: false,
+            skip_to: None,
         }
     }
 }
@@ -273,6 +280,14 @@ mod tests {
     fn it_should_return_no_headers_if_empty() {
         let headers = hdr!();
         assert_eq!(headers.len(), 0);
+    }
+
+    #[test]
+    fn it_should_skip_to_a_step() {
+        let req = Request::new(Method::GET, "https://google.com".to_string())
+            .skip_to(Some("RobotsTxt".to_string()))
+            .build();
+        assert_eq!(req.get_skip_to_step().unwrap(), "RobotsTxt");
     }
 
     #[test]

--- a/src/steps.rs
+++ b/src/steps.rs
@@ -36,10 +36,9 @@ impl StepManager {
     pub fn insert_arc(&mut self, step: Arc<dyn Stepable>) {
         self.handlers.insert(step.name().parse().unwrap(), step);
     }
-
     pub fn insert_many(&mut self, steps: Vec<Arc<dyn Stepable>>) {
         for step in steps {
-            self.handlers.insert(step.name().parse().unwrap(), step);
+            self.insert_arc(step);
         }
     }
 


### PR DESCRIPTION
Todo List Item: [X] Allow for skipping steps during `on_request()`

### New Methods:
Added `skip_to` method to set the step to be skipped to.
Added `get_skip_to_step` to retrieve the step to be skipped to.
Added `is_skipped` to check if a step is marked for skipping.

### Modified Behavior:
Updated `try_step` to return `Ok()` if the current step is set to be skipped, allowing for smooth transition to the next step.

### Impact and Future Considerations
**Ease of Use**: This feature should make it easier for programs to conditionally skip steps without having to alter the overall logic or state.

**Explicitness**: The current implementation might require further refinement for more explicit behavior in future iterations